### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_graphgear extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($data, $state, $pos, &$handler){
+    function handle($data, $state, $pos, Doku_Handler $handler){
         $data = explode("\n",$data);
         $conf  = array_shift($data);
         array_pop($data);
@@ -78,7 +78,7 @@ class syntax_plugin_graphgear extends DokuWiki_Syntax_Plugin {
         );
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'xhtml') return false;
 
         $R->doc .= sprintf('<object width="%d" height="%d">


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
